### PR TITLE
change links from absolute to relative

### DIFF
--- a/Hydropi_WebSite/php/top_menu.php
+++ b/Hydropi_WebSite/php/top_menu.php
@@ -17,11 +17,11 @@ echo "        \n<body onload=\"updateClock(); setInterval('updateClock()', 1000)
                 </div>
                 <div id=\"navbar\" class=\"navbar-collapse collapse navbar-right\">
                     <ul class=\"nav navbar-nav\">
-                        <li><a href=\"/index.php\">Home</a></li>
-                        <li><a href=\"/graphs.php\">Graphs</a></li>
-                        <li><a href=\"/timers.php\">Timers</a></li>
-                        <li><a href=\"/dosage.php\">Dosage</a></li>
-                        <li><a href=\"/settings.php\">Settings</a></li>
+                        <li><a href=\"index.php\">Home</a></li>
+                        <li><a href=\"graphs.php\">Graphs</a></li>
+                        <li><a href=\"timers.php\">Timers</a></li>
+                        <li><a href=\"dosage.php\">Dosage</a></li>
+                        <li><a href=\"settings.php\">Settings</a></li>
                     </ul>
                 </div><!--.nav-collapse -->
             </div>


### PR DESCRIPTION
change links from absolute to relative.

When hosting this on a sub directory.
e.g
in /var/www/html/HydroPi/ instead of the base html/

and when trying to use the link to access settings.php, it would try to link to http://siteName/settings.php instead of http://siteName/HydroPi/settings.php