### PR TITLE
change favicon to relative and https for script

### DIFF
--- a/Hydropi_WebSite/dosage.php
+++ b/Hydropi_WebSite/dosage.php
@@ -10,7 +10,7 @@
             <meta name="author" content="">
             <link rel="icon"
                   type="image/png"
-                  href="http://YourWebsite.com/favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
+                  href="favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
             <title>HydroPi - Pool Monitor</title>
 
             <!-- Bootstrap core CSS -->
@@ -143,7 +143,7 @@ echo "                          <button class=\"btn btn-info\" name=\"singlebutt
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- Custom JavaScript
     ================================================== -->

--- a/Hydropi_WebSite/graphs.php
+++ b/Hydropi_WebSite/graphs.php
@@ -10,7 +10,7 @@
             <meta name="author" content="">
             <link rel="icon"
                   type="image/png"
-                  href="http://YourWebsite.com/favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
+                  href="favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
             <title>HydroPi - Pool Monitor</title>
 
             <!-- Bootstrap core CSS -->
@@ -81,7 +81,7 @@ echo "                </div>\n";
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- Google Charts JavaScript
     ================================================== -->

--- a/Hydropi_WebSite/index.php
+++ b/Hydropi_WebSite/index.php
@@ -12,7 +12,7 @@
             <meta name="author" content="">
             <link rel="icon"
                   type="image/png"
-                  href="http://YourWebsite.com/favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
+                  href="favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
             <title>HydroPi - Pool Monitor</title>
 
             <!-- Bootstrap core CSS -->
@@ -142,7 +142,7 @@ echo "                      </div>\n";
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- Custom JavaScript
     ================================================== -->

--- a/Hydropi_WebSite/settings.php
+++ b/Hydropi_WebSite/settings.php
@@ -10,7 +10,7 @@
             <meta name="author" content="">
             <link rel="icon"
                   type="image/png"
-                  href="http://YourWebsite.com/favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
+                  href="favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
 
             <title>HydroPi - Pool Monitor</title>
 
@@ -118,7 +118,7 @@ echo "                              </div>\n";
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- Custom JavaScript
     ================================================== -->

--- a/Hydropi_WebSite/timers.php
+++ b/Hydropi_WebSite/timers.php
@@ -10,7 +10,7 @@
             <meta name="author" content="">
             <link rel="icon"
                   type="image/png"
-                  href="http://YourWebsite.com/favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
+                  href="favicon.png"> <!-- Or href="http://localhost/favicon.png"> -->
             <title>HydroPi - Pool Monitor</title>
 
             <!-- Bootstrap core CSS -->
@@ -84,7 +84,7 @@ echo "              </script>\n";
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- Custom JavaScript
     ================================================== -->


### PR DESCRIPTION
change favicon.png to relative link so that it always work no matter the name/ip of the sites, and change the bootstrap.min.js to load via https instead of http. else if hosting the site on https, it will show as insecure because this scripts was being loaded via http.